### PR TITLE
Fix chart rendering against helm 2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog 
 # 
+## 0.2.6: October 22, 2019
+- Explicitly cast `clusterSize` to fix type comparison in `helm` `2.15.0`
 ## 0.2.5: August 30, 2019
 - __Potentially breaking__: Add release namespace to all resources to work with `helm template`
 See https://github.com/helm/helm/issues/5465 for more information.

--- a/stable/eventstore/Chart.yaml
+++ b/stable/eventstore/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: A Helm chart for Kubernetes EventStore.
 name: eventstore
 home: https://eventstore.org/
-version: 0.2.5
+version: 0.2.6
 appVersion: 4.1.1-hotfix1
 keywords:
   - eventstore

--- a/stable/eventstore/templates/NOTES.txt
+++ b/stable/eventstore/templates/NOTES.txt
@@ -9,7 +9,7 @@ You can access Event Store:
 
   * Within your cluster, using the following URI:
 
-    {{ if gt .Values.clusterSize 1.0 }}
+    {{ if gt (.Values.clusterSize | float64) 1.0 }}
     discover://{{ include "eventstore.dns" . }}:{{ .Values.extHttpPort }}
     {{ else }}
     tcp://{{ include "eventstore.dns" . }}:{{ .Values.extTcpPort }}
@@ -17,7 +17,7 @@ You can access Event Store:
 
     ref: https://eventstore.org/docs/dotnet-api/connecting-to-a-server/index.html#uris
 
-{{- if gt .Values.clusterSize 1.0 }}
+{{- if gt (.Values.clusterSize | float64) 1.0 }}
 You can access the Event Store admin interface:
   * From outside the cluster:
     {{- if contains "NodePort" .Values.admin.serviceType }}

--- a/stable/eventstore/templates/eventstore-statefulset.yaml
+++ b/stable/eventstore/templates/eventstore-statefulset.yaml
@@ -63,7 +63,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             {{- end }}
-          {{- if and .Values.extIp (gt .Values.clusterSize 1.0) }}
+          {{- if and .Values.extIp (gt (.Values.clusterSize | float64) 1.0) }}
             - name: EVENTSTORE_EXT_IP_ADVERTISE_AS
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
#### PR Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] CHANGELOG.md updated

**What this PR does / why we need it**:
This chart fails to render against Helm `2.15.0`, it complains of a type mismatch:

```
Error: render error in "eventstore/templates/eventstore-statefulset.yaml": template: eventstore/templates/eventstore-statefulset.yaml:66:36: executing "eventstore/templates/eventstore-statefulset.yaml" at <gt .Values.clusterSize 1.0>: error calling gt: incompatible types for comparison
```
This PR resolves that by explicitly casting `clusterSize` to `float64`